### PR TITLE
Parameterized recursive inotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 The one-liner to spin up a code search engine
 
-OpenGrok is a code search engine made by Sun (and now Oracle). It provides
-similar functions to [LXR](http://lxr.linux.no/) but more. This project
-encapsulated OpenGrok into a docker container. Allowing you to start an
-instance of OpenGrok by one command.
+[OpenGrok](http://opengrok.github.io/OpenGrok/) is a code search engine 
+made by Sun (and now Oracle). 
+
+It provides similar functions to [LXR](http://lxr.linux.no/) but much more. 
+This project encapsulated OpenGrok into a docker container, allowing you 
+to start an instance of OpenGrok by one command.
 
 ## Usage
 
 To start the OpenGrok, simply run:
 
 ```sh
-docker run -d -v [source to be indexed on host]:/src -p [public port]:8080 steinwaywhw/opengrok
+docker run -d -v [source to be indexed on host]:/src -p [public port]:8080 itszero/opengrok
 ```
 
 It may take a while for the indexer to finish the first-time indexing, after
@@ -20,4 +22,8 @@ that, the search engine is available at `http://host:[public port]/source/`.
 
 ## Note
 
-The project supports dynamic index updating through `inotifywait` recursively on the source folder. However, `touch` doesn't help. You should add or delete or modify the content of some source file to make it happen.
+The project supports dynamic index updating through `inotifywait` recursively on the source folder. 
+This can be disabled with the environment variable `INOTIFY_NOT_RECURSIVE` at runtime.
+Also, if you have more than 8192 files to watch, you will need to increase the amount of inotify watches allowed per user `(/proc/sys/fs/inotify/max_user_watches)` on your host system.
+
+NOTE: `touch` doesn't trigger inotify. You should add, delete or modify the content of some source file to make it happen.

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,14 @@ cd /opengrok/bin
 # ... and we keep running the indexer to keep the container on
 echo "** Waiting for source updates..."
 touch $OPENGROK_INSTANCE_BASE/reindex
-inotifywait -mr -e CLOSE_WRITE $OPENGROK_INSTANCE_BASE/src | while read f; do
+
+if [ $INOTIFY_NOT_RECURSIVE ]; then
+  INOTIFY_CMDLINE="inotifywait -m -e CLOSE_WRITE $OPENGROK_INSTANCE_BASE/reindex"
+else
+  INOTIFY_CMDLINE="inotifywait -mr -e CLOSE_WRITE $OPENGROK_INSTANCE_BASE/src"
+fi
+
+$INOTIFY_CMDLINE | while read f; do
   printf "*** %s\n" "$f"
   echo "*** Updating index"
   ./OpenGrok index


### PR DESCRIPTION
I was testing your dockerfile but as I have a lot of repos, I got this error:

```
Failed to watch /grok/src; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
```

As I update all my repos once per day, I rather disable recursive watching and trigger the OpenGrok update manually after updating my data.