### PR TITLE
upgraded opengrok 0.12.1.6, base image to ubuntu 16.10 and openjdk to…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.10
 MAINTAINER Zero Cho "http://itsze.ro/"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV OPENGROK_INSTANCE_BASE /grok
 
 RUN apt-get update
-RUN apt-get install -y openjdk-7-jre-headless exuberant-ctags git subversion mercurial tomcat7 wget inotify-tools
+RUN apt-get install -y openjdk-8-jre-headless exuberant-ctags git subversion mercurial tomcat7 wget inotify-tools unzip
 ADD install.sh /usr/local/bin/install
 RUN /usr/local/bin/install
 ADD run.sh /usr/local/bin/run

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,9 @@ mkdir $OPENGROK_INSTANCE_BASE
 mkdir $OPENGROK_INSTANCE_BASE/data
 mkdir $OPENGROK_INSTANCE_BASE/etc
 
-wget -O - https://java.net/projects/opengrok/downloads/download/opengrok-0.12.1.tar.gz | tar zxvf -
+wget https://github.com/OpenGrok/OpenGrok/files/467358/opengrok-0.12.1.6.tar.gz.zip
+unzip -p opengrok-0.12.1.6.tar.gz.zip | tar zxvf -
+rm opengrok-0.12.1.6.tar.gz.zip
 mv opengrok-* opengrok
 cd /opengrok/bin
 ./OpenGrok deploy


### PR DESCRIPTION
Hello @itszero,

I don't know if you take requests but I upgraded to opengrok version 0.12.1.6 which means new download site. In the same go I upgraded the base image to Ubuntu 16.10 and and the openjdk to version 8.
